### PR TITLE
20 admin dashboard links

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -1,0 +1,5 @@
+class Admin::InvoicesController < ApplicationController
+  def index
+    
+  end
+end

--- a/app/views/admin/_admin_header.html.erb
+++ b/app/views/admin/_admin_header.html.erb
@@ -1,0 +1,5 @@
+<header>
+  <h1>Admin Dashboard</h1>
+  <%= link_to "Merchants", admin_merchants_path %>
+  <%= link_to "Invoices", admin_invoices_path %>
+</header>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,3 +1,6 @@
 <header>
   <h1>Admin Dashboard</h1>
 </header>
+
+<p><%= link_to "Merchants", admin_merchants_path %></p>
+<p><%= link_to "Invoices", admin_invoices_path %></p>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -1,6 +1,1 @@
-<header>
-  <h1>Admin Dashboard</h1>
-</header>
-
-<p><%= link_to "Merchants", admin_merchants_path %></p>
-<p><%= link_to "Invoices", admin_invoices_path %></p>
+<%= render "admin_header" %>

--- a/app/views/admin/invoices/index.html.erb
+++ b/app/views/admin/invoices/index.html.erb
@@ -1,0 +1,1 @@
+<h1>Admin Invoices Index Page</h1>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :merchants, only: [:index, :show], controller: "merchants"
+    resources :invoices, only: [:index]
   end
 
   resources :merchants do

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -17,17 +17,18 @@ RSpec.describe "Admin Dashboard Index Page" do
     it "displays a link to the admin merchants index page" do
       visit admin_path
 
-      expect(page).to have_link("Merchants", href: "/admin/merchants")
-      click_on("Merchants")
-      expect(page).to have_current_path("/admin/merchants")
+      expect(page).to have_link("Merchants", href: admin_merchants_path)
+      
+      click_link("Merchants")
+      expect(page).to have_current_path(admin_merchants_path)
     end
 
     it "displays a link to the admin invoices index page" do
       visit admin_path
 
-      expect(page).to have_link("Invoices", href: "/admin/invoices")
-      click_on("Invoices")
-      expect(page).to have_current_path("/admin/invoices")
+      expect(page).to have_link("Invoices", href: admin_invoices_path)
+      click_link("Invoices")
+      expect(page).to have_current_path(admin_invoices_path)
     end
   end
 end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe "Admin Dashboard Index Page" do
       visit admin_path
 
       expect(page).to have_link("Merchants", href: admin_merchants_path)
-      
       click_link("Merchants")
       expect(page).to have_current_path(admin_merchants_path)
     end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -6,12 +6,28 @@ RSpec.describe "Admin Dashboard Index Page" do
   end
 
   describe "Admin Dashboard Display" do
-    
     # User Story 19
     it "displays a header indicating that it is the admin dashboard" do
       visit admin_path
 
       expect(page).to have_content("Admin Dashboard")
+    end
+
+    # User Story 20
+    it "displays a link to the admin merchants index page" do
+      visit admin_path
+
+      expect(page).to have_link("Merchants", href: "/admin/merchants")
+      click_on("Merchants")
+      expect(page).to have_current_path("/admin/merchants")
+    end
+
+    it "displays a link to the admin invoices index page" do
+      visit admin_path
+
+      expect(page).to have_link("Invoices", href: "/admin/invoices")
+      click_on("Invoices")
+      expect(page).to have_current_path("/admin/invoices")
     end
   end
 end


### PR DESCRIPTION
This PR completes User Story 20 (and part of 32).
- Added hyperlinks to admin/merchants and admin/invoices to the header of admin index page
- moved admin header to a partial so it can be used for all admin pages
- created route/controller/view for admin/invoices index page(needed for the header hyperlink to work) -- left this admin/invoices index page blank (only a title on it right now)