### PR TITLE
Us27/admin merchant enabledisable

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -21,6 +21,7 @@ class Admin::MerchantsController < ApplicationController
       else
         flash[:error] = "Merchant must have a name"
         render :edit
+        # redirect_to edit_admin_merchant_path(@merchant_2)
       end
     end
   end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -15,20 +15,21 @@ class Admin::MerchantsController < ApplicationController
   def update
     @merchant = Merchant.find(params[:id])
 
-    if @merchant
-      if @merchant.update(merchant_params)
-        flash[:success] = "#{@merchant.name} was successfully updated"
-        redirect_to admin_merchant_path(@merchant)
-      else
-        flash[:error] = "Merchant must have a name"
-        redirect_to edit_admin_merchant_path(@merchant)
-      end
+    if @merchant.update(merchant_params)
+      !params[:merchant][:status].nil?
+      redirect_to admin_merchants_path
+    elsif
+      flash[:success] = "#{@merchant.name} was successfully updated"
+      redirect_to admin_merchant_path(@merchant)
+    else
+      flash[:error] = "Merchant must have a name"
+      redirect_to edit_admin_merchant_path(@merchant)
     end
   end
 
 
   private
   def merchant_params
-    params.require(:merchant).permit(:name)
+    params.require(:merchant).permit(:name, :status)
   end
 end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,5 +1,6 @@
 class Admin::MerchantsController < ApplicationController
   def index
+    @enabled_merchants = Merchant.enabled_merchants
     @merchants = Merchant.all
   end
 

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,6 +1,7 @@
 class Admin::MerchantsController < ApplicationController
   def index
     @enabled_merchants = Merchant.enabled_merchants
+    @disabled_merchants = Merchant.disabled_merchants
     @merchants = Merchant.all
   end
 

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -14,14 +14,13 @@ class Admin::MerchantsController < ApplicationController
   def update
     @merchant = Merchant.find(params[:id])
 
-    if @merchant.update(merchant_params)
-      if params[:commit] == "Submit"
+    if @merchant
+      if @merchant.update(merchant_params)
         flash[:success] = "#{@merchant.name} was successfully updated"
         redirect_to admin_merchant_path(@merchant)
       else
         flash[:error] = "Merchant must have a name"
-        render :edit
-        # redirect_to edit_admin_merchant_path(@merchant_2)
+        redirect_to edit_admin_merchant_path(@merchant)
       end
     end
   end

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -17,11 +17,12 @@ class Admin::MerchantsController < ApplicationController
     @merchant = Merchant.find(params[:id])
 
     if @merchant.update(merchant_params)
-      !params[:merchant][:status].nil?
-      redirect_to admin_merchants_path
-    elsif
-      flash[:success] = "#{@merchant.name} was successfully updated"
-      redirect_to admin_merchant_path(@merchant)
+      if !params[:merchant][:status].nil?
+        redirect_to admin_merchants_path
+      else
+        flash[:success] = "#{@merchant.name} was successfully updated"
+        redirect_to admin_merchant_path(@merchant)
+      end
     else
       flash[:error] = "Merchant must have a name"
       redirect_to edit_admin_merchant_path(@merchant)

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -8,4 +8,8 @@ class Merchant < ApplicationRecord
   validates :name, presence: true
 
   enum status: {"disabled": 0, "enabled": 1}
+
+  def self.enabled_merchants
+    where('status = 1')
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -6,4 +6,6 @@ class Merchant < ApplicationRecord
   has_many :transactions, through: :invoices
 
   validates :name, presence: true
+
+  enum status: {"disabled": 0, "enabled": 1}
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -12,4 +12,8 @@ class Merchant < ApplicationRecord
   def self.enabled_merchants
     where('status = 1')
   end
+
+  def self.disabled_merchants
+    where('status = 0')
+  end
 end

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -2,7 +2,7 @@
 
 <h1>Merchant Edit Page</h1>
 
-<%= form_with model: [:admin, @merchant], local: true do |form| %>
+<%= form_with model: [:admin, @merchant], data: {turbo: false}, local: true do |form| %>
   <%= form.label :name %>
   <%= form.text_field :name %>
   <%= form.submit "Submit" %>

--- a/app/views/admin/merchants/edit.html.erb
+++ b/app/views/admin/merchants/edit.html.erb
@@ -1,8 +1,8 @@
 <%= render "/admin/admin_header" %>
 
-<h1>Merchant Edit Page</h1>
+<h1><%= @merchant.name %> Edit Page</h1>
 
-<%= form_with model: [:admin, @merchant], data: {turbo: false}, local: true do |form| %>
+<%= form_with model: [:admin, @merchant], local: true do |form| %>
   <%= form.label :name %>
   <%= form.text_field :name %>
   <%= form.submit "Submit" %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -11,7 +11,8 @@
     <h4>Enabled Merchants</h4>
     <% @enabled_merchants.each do |merchant| %>
       <li><%= link_to "#{merchant.name}", admin_merchant_path(merchant) %>
-        <%= form_with model: [:admin, merchant], local: true do |form| %>
+        <%= form_with model: merchant, url: admin_merchant_path(merchant), local: true do |form| %>
+          <%= form.hidden_field :method, value: "patch" %>
           <%= form.hidden_field :status, value: "disabled" %>
           <%= form.submit "Disable #{merchant.name}" %>
         <% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -1,11 +1,5 @@
 <%= render "/admin/admin_header" %>
 
-<h1>Admin Merchant Index Page</h1>
-
-  <% @merchants.each do |merchant| %>
-    <p><%= link_to merchant.name, admin_merchant_path(merchant) %></p>
-  <% end %>
-
 <section id="enabled_merchants">
   <ul>
     <h4>Enabled Merchants</h4>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -2,7 +2,11 @@
 
 <h1>Admin Merchant Index Page</h1>
 
-<h3>Merchants:</h3>
   <% @merchants.each do |merchant| %>
     <p><%= link_to merchant.name, admin_merchant_path(merchant) %></p>
   <% end %>
+
+<section id="enabled_merchants">
+  <h4>Enabled Merchants</h4>
+  
+</section>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -7,6 +7,15 @@
   <% end %>
 
 <section id="enabled_merchants">
-  <h4>Enabled Merchants</h4>
-  
+  <ul>
+    <h4>Enabled Merchants</h4>
+    <% @enabled_merchants.each do |merchant| %>
+      <li><%= link_to "#{merchant.name}", admin_merchant_path(merchant) %>
+        <%= form_with model: [:admin, merchant], local: true do |form| %>
+          <%= form.hidden_field :status, value: "disabled" %>
+          <%= form.submit "Disable #{merchant.name}" %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
 </section>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -20,3 +20,18 @@
     <% end %>
   </ul>
 </section>
+
+<section id="disabled_merchants">
+  <ul>
+    <h4>Disabled Merchants</h4>
+    <% @disabled_merchants.each do |merchant| %>
+      <li><%= link_to "#{merchant.name}", admin_merchant_path(merchant) %>
+        <%= form_with model: merchant, url: admin_merchant_path(merchant), local: true do |form| %>
+          <%= form.hidden_field :method, value: "patch" %>
+          <%= form.hidden_field :status, value: "enabled" %>
+          <%= form.submit "Enable #{merchant.name}" %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
   </head>
 
   <body>
+  <h1>Little Esty Shop</h1>
   <% flash.each do |type, message| %>
       <p><%= message %></p>
     <% end %>

--- a/db/migrate/20230602212525_add_enabled_to_merchants.rb
+++ b/db/migrate/20230602212525_add_enabled_to_merchants.rb
@@ -1,5 +1,0 @@
-class AddEnabledToMerchants < ActiveRecord::Migration[7.0]
-  def change
-    add_column :merchants, :enabled, :boolean, default: true
-  end
-end

--- a/db/migrate/20230602212525_add_enabled_to_merchants.rb
+++ b/db/migrate/20230602212525_add_enabled_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddEnabledToMerchants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :merchants, :enabled, :boolean, default: true
+  end
+end

--- a/db/migrate/20230602223134_add_status_to_merchants.rb
+++ b/db/migrate/20230602223134_add_status_to_merchants.rb
@@ -1,0 +1,5 @@
+class AddStatusToMerchants < ActiveRecord::Migration[7.0]
+  def change
+    add_column :merchants, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_02_212525) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_02_223134) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,7 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_02_212525) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "enabled", default: true
+    t.integer "status", default: 0
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_31_180707) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_02_212525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_31_180707) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "enabled", default: true
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -23,5 +23,14 @@ RSpec.describe "Admin Merchant Edit Form", type: :feature do
       expect(page).to have_content("Jim Bob's")
       expect(page).to have_content("Jim Bob's was successfully updated")
     end
+
+    it "will re-render the edit form if fields are left blank" do
+      visit edit_admin_merchant_path(@merchant_2)
+      fill_in("Name", with: "" )
+      click_button("Submit")
+
+      expect(current_path).to eq(edit_admin_merchant_path(@merchant_2))
+      expect(page).to have_content("Merchant must have a name")
+    end
   end
 end

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Admin Merchant Edit Form", type: :feature do
     it "has the existing merchant attribute information" do
       visit edit_admin_merchant_path(@merchant_1)
       
-      expect(page).to have_content("Merchant Edit Page")
+      expect(page).to have_content("#{@merchant_1.name} Edit Page")
       expect(page).to have_field('Name', with: @merchant_1.name)
     end
     

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
         click_button("Disable #{@merchant_2.name}")
         expect(current_path).to eq(admin_merchants_path)
       end
-      expect(page).to have_button("Enable #{@merchant_2.name}")
+      # expect(page).to have_button("Enable #{@merchant_2.name}")
     end
 
-    xit "has a section for disabled merchants with a button to enable that merchant" do
+    it "has a section for disabled merchants with a button to enable that merchant" do
       visit admin_merchants_path
 
       within "#disabled_merchants" do

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
   before(:each) do
     @merchant_1 = create(:merchant, status: 0)
     @merchant_2 = create(:merchant, status: 1)
+    @merchant_3 = create(:merchant, status: 0)
+    @merchant_4 = create(:merchant, status: 1)
+    @merchant_5 = create(:merchant, status: 1)
   end
 
   describe "When I visit the admin merchants index" do
@@ -27,16 +30,16 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
   end
   
   describe "Sections for Disabling and Enabling Merchants" do
-    xit "has a section for enabled merchants with a button to disable that merchant" do
+    it "has a section for enabled merchants with a button to disable that merchant" do
       visit admin_merchants_path
-  
+
       within "#enabled_merchants" do
         expect(page).to have_button("Disable #{@merchant_2.name}")
   
         click_button("Disable #{@merchant_2.name}")
         expect(current_path).to eq(admin_merchants_path)
       end
-      expect(page).to have_content("#{@merchant_2.name} is Disabled")
+      expect(page).to have_button("Enable #{@merchant_2.name}")
     end
 
     xit "has a section for disabled merchants with a button to enable that merchant" do
@@ -48,7 +51,7 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
         click_button("Enable #{@merchant_1.name}")
         expect(current_path).to eq(admin_merchants_path)
       end
-      expect(page).to have_content("#{@merchant_1.name} is Enabled")
+      expect(page).to have_button("Disable #{@merchant_2.name}")
     end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe "Admin Merchant Index Page", type: :feature do
   before(:each) do
-    @merchant_1 = create(:merchant, enabled: false)
-    @merchant_2 = create(:merchant, enabled: true)
+    @merchant_1 = create(:merchant, status: 0)
+    @merchant_2 = create(:merchant, status: 1)
   end
 
   describe "When I visit the admin merchants index" do

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe "Admin Merchant Index Page", type: :feature do
   before(:each) do
-    @merchant_1 = create(:merchant)
-    @merchant_2 = create(:merchant)
+    @merchant_1 = create(:merchant, enabled: false)
+    @merchant_2 = create(:merchant, enabled: true)
   end
 
   describe "When I visit the admin merchants index" do
@@ -18,12 +18,38 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
     
     it "each merchant name is a link to that merchant's show page" do
       visit admin_merchants_path
-
+      
       expect(page).to have_link(@merchant_1.name)
       expect(page).to have_link(@merchant_2.name)
-
+      
       click_link(@merchant_1.name)
       expect(current_path).to eq(admin_merchant_path(@merchant_1))
+    end
+  end
+  
+  describe "Sections for Disabling and Enabling Merchants" do
+    it "has a section for enabled merchants with a button to disable that merchant" do
+      visit admin_merchants_path
+  
+      within "#enabled_merchants_#{@merchant_2.id}" do
+        expect(page).to have_button("Disable #{@merchant_2.name}")
+  
+        click_button("Disable #{@merchant_2.name}")
+        expect(current_path).to eq(admin_merchants_path)
+      end
+      expect(page).to have_content("#{@merchant_2.name} is Disabled")
+    end
+
+    xit "has a section for disabled merchants with a button to enable that merchant" do
+      visit admin_merchants_path
+
+      within "#disabled_merchants_#{@merchant_1.id}" do
+        expect(page).to have_button("Enable #{@merchant_1.name}")
+
+        click_button("Enable #{@merchant_1.name}")
+        expect(current_path).to eq(admin_merchants_path)
+      end
+      expect(page).to have_content("#{@merchant_1.name} is Enabled")
     end
   end
 end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
     it "displays the name of each merchant in the system" do
       visit admin_merchants_path
       
-      expect(page).to have_content("Admin Merchant Index Page")
       expect(page).to have_content(@merchant_1.name)
       expect(page).to have_content(@merchant_2.name)
     end
@@ -39,7 +38,7 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
         click_button("Disable #{@merchant_2.name}")
         expect(current_path).to eq(admin_merchants_path)
       end
-      # expect(page).to have_button("Enable #{@merchant_2.name}")
+      expect(page).to have_button("Enable #{@merchant_2.name}")
     end
 
     it "has a section for disabled merchants with a button to enable that merchant" do

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
       visit admin_merchants_path
       
       expect(page).to have_content("Admin Merchant Index Page")
-      expect(page).to have_content("Merchants:")
       expect(page).to have_content(@merchant_1.name)
       expect(page).to have_content(@merchant_2.name)
     end
@@ -28,10 +27,10 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
   end
   
   describe "Sections for Disabling and Enabling Merchants" do
-    it "has a section for enabled merchants with a button to disable that merchant" do
+    xit "has a section for enabled merchants with a button to disable that merchant" do
       visit admin_merchants_path
   
-      within "#enabled_merchants_#{@merchant_2.id}" do
+      within "#enabled_merchants" do
         expect(page).to have_button("Disable #{@merchant_2.name}")
   
         click_button("Disable #{@merchant_2.name}")
@@ -43,7 +42,7 @@ RSpec.describe "Admin Merchant Index Page", type: :feature do
     xit "has a section for disabled merchants with a button to enable that merchant" do
       visit admin_merchants_path
 
-      within "#disabled_merchants_#{@merchant_1.id}" do
+      within "#disabled_merchants" do
         expect(page).to have_button("Enable #{@merchant_1.name}")
 
         click_button("Enable #{@merchant_1.name}")

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.describe Merchant, type: :model do
+  before(:each) do
+    @merchant_1 = create(:merchant, status: 0)
+    @merchant_2 = create(:merchant, status: 0)
+    @merchant_3 = create(:merchant, status: 1)
+    @merchant_4 = create(:merchant, status: 1)
+    @merchant_5 = create(:merchant, status: 1)
+  end
   describe "Relationships" do
     it { should have_many(:items)}
     it { should have_many(:invoice_items).through(:items)}
@@ -16,11 +23,11 @@ RSpec.describe Merchant, type: :model do
   describe "Class Methods" do
     describe ".enabled_merchants" do
       it "groups merchants based on their enabled status" do
-        expect(Merchant.enabled_merchants).to eq()
+        expect(Merchant.enabled_merchants).to eq([@merchant_3, @merchant_4, @merchant_5])
       end
 
       xit "groups merchants based on their disabled status" do
-        expect(Merchant.disabled_merchants).to eq()
+        expect(Merchant.disabled_merchants).to eq([@merchant_1, @merchant_2])
       end
     end
   end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Merchant, type: :model do
         expect(Merchant.enabled_merchants).to eq([@merchant_3, @merchant_4, @merchant_5])
       end
 
-      xit "groups merchants based on their disabled status" do
+      it "groups merchants based on their disabled status" do
         expect(Merchant.disabled_merchants).to eq([@merchant_1, @merchant_2])
       end
     end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -12,4 +12,16 @@ RSpec.describe Merchant, type: :model do
   describe "Validations" do
     it { should validate_presence_of :name }
   end
+
+  describe "Class Methods" do
+    describe ".enabled_merchants" do
+      it "groups merchants based on their enabled status" do
+        expect(Merchant.enabled_merchants).to eq()
+      end
+
+      xit "groups merchants based on their disabled status" do
+        expect(Merchant.disabled_merchants).to eq()
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR contains the work for user stories 27 AND 28.
It was easier to combine the two rather than complete 27, then refactor for 28.
Merchants are divided between a enabled and disabled section with the appropriate button to switch merchant status.

Migration created to add status to a merchant - default to zero with enums defined in model
"Little Esty Shop" Added to the application.html.erb file so the header shows on every page. (Still needs centered)

Model methods fully tested and the index action in the admin merchant's controller was updated.
Had to add an additional conditional to the update action in the controller to accommodate for status changes.
Routes updated accordingly keepin' it RESTful.

Form with models still had to have the path and method defined for some reason.
I will be refactoring the enable/disable forms into a partial at a later time. 