### PR TITLE
Minor invoice model changes

### DIFF
--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -114,7 +114,6 @@ RSpec.describe "Admin Dashboard Index Page" do
     # User Story 22
     it "displays the IDs of invoices that have items that have not yet been shipped" do
       visit admin_path
-      save_and_open_page
 
       within("#incomplete-invoices") do
         expect(page).to have_content("Incomplete Invoices")

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe Invoice, type: :model do
   describe "Class Methods" do
     describe "#incomplete_invoices" do
       it "returns the invoices with items that have not been shipped" do
-        expect(Invoice.incomplete_invoices).to eq([@invoice_1, @invoice_3])
+        expect(Invoice.incomplete_invoices).to include(@invoice_1, @invoice_3)
+        expect(Invoice.incomplete_invoices).to_not include(@invoice_2)
       end
     end
   end


### PR DESCRIPTION
just had to change how I was testing the #incomplete_invoices method in the Invoice model. Since the order of the invoices in the returned array cannot be predicted, I switch from `.equals([@invoice_1, @invoice_2]) `to .`includes(@invoice_1, @invoice_2)`