### PR TITLE
23 admin dashboard invoices sorted by least recent

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -8,6 +8,6 @@ class Invoice < ApplicationRecord
   enum status: {"in progress": 0, "completed": 1, "cancelled": 2}
 
   def self.incomplete_invoices
-    Invoice.joins(:invoice_items).where.not("invoice_items.status = 2").distinct
+    Invoice.joins(:invoice_items).where.not("invoice_items.status = 2").distinct.order(created_at: :desc)
   end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -13,7 +13,7 @@
   <h3>Incomplete Invoices</h3>
   <ul>
     <% @invoices.each do |invoice| %>
-    <li><%= link_to "Invoice ##{invoice.id}", admin_invoice_path(invoice) %></li>
+    <li><%= link_to "Invoice ##{invoice.id}", admin_invoice_path(invoice)%> - <%= invoice.created_at.strftime("%A, %B %d, %Y")%></li>
     <% end %>
   </ul>
 </section>

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -135,5 +135,21 @@ RSpec.describe "Admin Dashboard Index Page" do
         expect(page).to have_current_path(admin_invoice_path(@invoice_1))
       end
     end
+
+    # User Story 23
+    it "displays invoices sorted by oldest to newest" do
+      visit admin_path
+      save_and_open_page
+      within("#incomplete-invoices") do
+        expect("#{@invoice_6.id}").to appear_before("#{@invoice_5.id}")
+        expect("#{@invoice_5.id}").to appear_before("#{@invoice_4.id}")
+        expect("#{@invoice_4.id}").to appear_before("#{@invoice_2.id}")
+        expect("#{@invoice_2.id}").to appear_before("#{@invoice_1.id}")
+      end
+    end
+
+    it "displays the date_created next to each invoice" do
+
+    end
   end
 end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "Admin Dashboard Index Page" do
     # User Story 23
     it "displays invoices sorted by oldest to newest" do
       visit admin_path
-      save_and_open_page
+
       within("#incomplete-invoices") do
         expect("#{@invoice_6.id}").to appear_before("#{@invoice_5.id}")
         expect("#{@invoice_5.id}").to appear_before("#{@invoice_4.id}")
@@ -149,7 +149,12 @@ RSpec.describe "Admin Dashboard Index Page" do
     end
 
     it "displays the date_created next to each invoice" do
+      visit admin_path
 
+      within("#incomplete-invoices") do
+        expect(page).to have_content("#{@invoice_1.id} - #{@invoice_1.created_at.strftime("%A, %B %d, %Y")}")
+        expect(page).to have_content("#{@invoice_2.id} - #{@invoice_2.created_at.strftime("%A, %B %d, %Y")}")
+      end
     end
   end
 end


### PR DESCRIPTION
Completes User Story 23.
- changes `incomplete_invoices` to order the invoices from oldest to newest created
- adds the date_created to the end of each incomplete invoice listed on the view