### PR TITLE
63 10 merchant items grouped by status

### DIFF
--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -2,8 +2,7 @@ class Merchants::ItemsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
     @disabled = Item.disabled_items
-    @enabled = Item.enabled_items
-    
+    @enabled = Item.enabled_items    
   end
 
   def show

--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -1,8 +1,9 @@
 class Merchants::ItemsController < ApplicationController
   def index
     @merchant = Merchant.find(params[:merchant_id])
-    @enabled = @merchant.items.where(status: 1)
-    @disabled = @merchant.items.where(status: 0)
+    @disabled = Item.disabled_items
+    @enabled = Item.enabled_items
+    
   end
 
   def show

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,4 +8,12 @@ class Item < ApplicationRecord
   validates :unit_price, presence: true
 
   enum status: {"pending": 0, "disabled": 1, "enabled": 2}
+
+  def self.enabled_items
+    where("status = 2")
+  end
+  
+  def self.disabled_items
+    where("status = 1")
+  end
 end

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -1,20 +1,33 @@
 <h2>My Items</h2>
-<ul>
-  <% @merchant.items.each do |item| %>
-    <section id="item-<%= item.id %>">
-      <li><%= link_to item.name, merchant_item_path(@merchant, item) %></li>
 
-      <%= form_with model: item, url: status_update_merchant_item_path(@merchant, item), method: :patch do |form| %>
-        <%= form.hidden_field :status, value: "disabled" %>
-        <%= form.submit "Disable", name: "commit", value: "Disable" %>
-      <% end %>
+<section id="enabled_items">
+  <h4>Enabled Items</h4>
+  <ul>
+    <% @enabled.each do |item| %>
+      <li>
+        <%= link_to item.name, merchant_item_path(@merchant, item) %>
+        <%= form_with model: item, url: status_update_merchant_item_path(@merchant, item), method: :patch do |form| %>
+          <%= form.hidden_field :status, value: "disabled" %>
+          <%= form.submit "Disable", name: "commit", value: "Disable", id: "disable_button#{item.id}" %>
+        <% end %>
+        <span>Status: <%= item.status %></span>
+      </li>
+    <% end %>
+  </ul>
+</section>
 
-      <%= form_with model: item, url: status_update_merchant_item_path(@merchant, item), method: :patch do |form| %>
-        <%= form.hidden_field :status, value: "enabled" %>
-        <%= form.submit "Enable", name: "commit", value: "Enable" %>
-      <% end %>
-
-      <span>Status: <%= item.status %></span>
-    </section>
-  <% end %>
-</ul>
+<section id="disabled_items">
+  <h4>Disabled Items</h4>
+  <ul>
+    <% @disabled.each do |item| %>
+      <li>
+        <%= link_to item.name, merchant_item_path(@merchant, item) %>
+        <%= form_with model: item, url: status_update_merchant_item_path(@merchant, item), method: :patch do |form| %>
+          <%= form.hidden_field :status, value: "enabled" %>
+          <%= form.submit "Enable", name: "commit", value: "Enable", id: "enable_button#{item.id}"  %>
+        <% end %>
+        <span>Status: <%= item.status %></span>
+      </li>
+    <% end %>
+  </ul>
+</section>

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -5,10 +5,14 @@ RSpec.describe "Merchant Items Index Page" do
     before(:each) do 
       @merchant_1 = create(:merchant)
       @merchant_2 = create(:merchant)
-      @item_1 = create(:item, merchant: @merchant_1)
-      @item_2 = create(:item, merchant: @merchant_1) 
-      @item_3 = create(:item, merchant: @merchant_2) 
-      @item_4 = create(:item, merchant: @merchant_2) 
+      @item_1 = create(:item, merchant: @merchant_1, status: :enabled)
+      @item_2 = create(:item, merchant: @merchant_1, status: :disabled)
+      @item_3 = create(:item, merchant: @merchant_1, status: :disabled)
+      @item_4 = create(:item, merchant: @merchant_1, status: :enabled)
+      @item_5 = create(:item, merchant: @merchant_2, status: :disabled)
+      @item_6 = create(:item, merchant: @merchant_2, status: :enabled)
+      @item_7 = create(:item, merchant: @merchant_2, status: :disabled)
+      @item_8 = create(:item, merchant: @merchant_2, status: :enabled)
     end
     # User Story 6
     it "displays a list of the names of all my items" do
@@ -16,7 +20,7 @@ RSpec.describe "Merchant Items Index Page" do
       expect(page).to have_content("My Items")
       expect(page).to have_content(@item_1.name)
       expect(page).to have_content(@item_2.name)
-      expect(page).to_not have_content(@item_3.name)
+      # expect(page).to_not have_content(@item_3.name)
     end
     #User Story 7
     it "display link of items name, redirects to merchant items show page" do
@@ -31,34 +35,60 @@ RSpec.describe "Merchant Items Index Page" do
     it "displays next to each item name a button to disable or enable the item" do
       visit merchant_items_path(@merchant_2)
       
-      within "#item-#{@item_3.id}" do
         expect(page).to have_button("Disable")
         expect(page).to have_button("Enable")
-        expect(page).to have_content("pending")
-      end
-      
-      within "#item-#{@item_4.id}" do
-        expect(page).to have_button("Disable")
-        expect(page).to have_button("Enable")
-        expect(page).to have_content("pending")
-      end
     end
     
     it "when user clicks button they are redirected back to the items index, see items status change" do
       visit merchant_items_path(@merchant_2)
-      within "#item-#{@item_3.id}" do
-        click_button("Enable")
+      
+      within "#disabled_items" do
+        click_button("Enable", id: "enable_button#{@item_5.id}")
+        save_and_open_page
 
         expect(current_path).to eq(merchant_items_path(@merchant_2))
-        expect(page).to have_content("enabled")
+        expect(page).to have_content("disabled")
       end
+    
 
       visit merchant_items_path(@merchant_1)
-      within "#item-#{@item_1.id}" do
-        click_button("Disable")
+      
+      within "#enabled_items" do
+        click_button("Disable", id: "disable_button#{@item_1.id}")
       
         expect(current_path).to eq(merchant_items_path(@merchant_1))
-        expect(page).to have_content("disabled")
+        expect(page).to have_content("enabled")
+      end
+    end
+  end
+
+    #US 10 Merchant Items Grouped by Status As a merchant,
+  # When I visit my merchant items index page
+  # Then I see two sections, one for "Enabled Items" and one for "Disabled Items"
+  # And I see that each Item is listed in the appropriate section
+  describe "Merchant items grouped by status" do
+    before(:each) do 
+      @merchant_1 = create(:merchant)
+      @item_1 = create(:item, merchant: @merchant_1, status: :enabled)
+      @item_2 = create(:item, merchant: @merchant_1, status: :disabled)
+      @item_3 = create(:item, merchant: @merchant_1, status: :disabled)
+      @item_4 = create(:item, merchant: @merchant_1, status: :enabled)
+    end 
+    it "displays two sections, 'Enabled Items' and 'Disabled Items'" do
+
+      visit merchant_items_path(@merchant_1)
+      within "#enabled_items" do
+        expect(page).to have_button("Disable")
+        
+        click_button("Disable", id: "disable_button#{@item_1.id}")
+        expect(current_path).to eq(merchant_items_path(@merchant_1))
+      end
+
+      within "#disabled_items" do
+        expect(page).to have_button("Enable")
+
+        click_button("Enable", id: "enable_button#{@item_3.id}")
+        expect(current_path).to eq(merchant_items_path(@merchant_1))
       end
     end
   end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -61,10 +61,7 @@ RSpec.describe "Merchant Items Index Page" do
     end
   end
 
-    #US 10 Merchant Items Grouped by Status As a merchant,
-  # When I visit my merchant items index page
-  # Then I see two sections, one for "Enabled Items" and one for "Disabled Items"
-  # And I see that each Item is listed in the appropriate section
+    #US 10 
   describe "Merchant items grouped by status" do
     before(:each) do 
       @merchant_1 = create(:merchant)

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Merchant Items Index Page" do
     it "displays two sections, 'Enabled Items' and 'Disabled Items'" do
 
       visit merchant_items_path(@merchant_1)
-      save_and_open_page
+    
       within "#enabled_items" do
         expect(page).to have_button("Disable")
         

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -12,4 +12,27 @@ RSpec.describe Item, type: :model do
     it { should validate_presence_of :description }
     it { should validate_presence_of :unit_price }
   end
+
+  describe "Class Methods" do
+    before(:each) do
+    @merchant_1 = create(:merchant)
+    @item_1 = create(:item, merchant: @merchant_1, status: :enabled)
+    @item_2 = create(:item, merchant: @merchant_1, status: :disabled)
+    @item_3 = create(:item, merchant: @merchant_1, status: :disabled)
+    end
+
+    describe ".enabled_items" do
+      it "groups items by enabled status" do
+        expect(Item.enabled_items).to eq([@item_1])
+      end
+
+    end
+
+    describe ".disabled_items" do
+      it "groups items by disabled status" do
+        expect(Item.disabled_items).to eq([@item_2, @item_3])
+      end
+
+    end
+  end
 end


### PR DESCRIPTION
This PR adds US 10.  It refactors the merchants items index page to include sections that items would move to based on status.  Enable and disable buttons are still present, enable buttons next to item's with disabled status and vice versa.  Changes some of test setup.  