### PR TITLE
34 admin invoice show page invoice item information

### DIFF
--- a/app/controllers/admin/invoices_controller.rb
+++ b/app/controllers/admin/invoices_controller.rb
@@ -6,4 +6,15 @@ class Admin::InvoicesController < ApplicationController
   def show
     @invoice = Invoice.find(params[:id])
   end
+
+  def update
+    @invoice = Invoice.find(params[:id])
+    @invoice.update(invoice_params)
+    redirect_to admin_invoice_path(@invoice)
+  end
+
+  private
+  def invoice_params
+    params.require(:invoice).permit(:status)
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -10,4 +10,8 @@ class Invoice < ApplicationRecord
   def self.incomplete_invoices
     Invoice.joins(:invoice_items).where.not("invoice_items.status = 2").distinct.order(created_at: :desc)
   end
+
+  def total_revenue
+    invoice_items.sum("unit_price * quantity")
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,4 +14,8 @@ class Item < ApplicationRecord
   def price_sold(invoice)
     invoice_items.where(invoice_id: invoice.id).pluck(:unit_price).first
   end
+
+  def invoice_status(invoice)
+    invoice_items.where(invoice_id: invoice.id).pluck(:status).first
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,4 +6,12 @@ class Item < ApplicationRecord
   validates :name, presence: true
   validates :description, presence: true
   validates :unit_price, presence: true
+
+  def num_sold(invoice)
+    invoice_items.where(invoice_id: invoice.id).pluck(:quantity).first
+  end
+
+  def price_sold(invoice)
+    invoice_items.where(invoice_id: invoice.id).pluck(:unit_price).first
+  end
 end

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -8,7 +8,12 @@
 
 <section id="invoice-item-details">
   <h4>Items on the Invoice:</h4>
-  <% @invoice.items.each do |item| %>
-    <p><%= item%></p>
-  <% end %>
+  <ul>
+    <% @invoice.items.each do |item| %>
+      <p><%= item.name %></p>
+      <li>Quantity: <%= item.num_sold(@invoice) %></li>
+      <li>Unit Price: <%= number_to_currency(item.price_sold(@invoice), format: '%u%n', unit: '$') %></li>
+      <li>Status: <%= item.invoice_status(@invoice) %></li>
+    <% end %>
+  </ul>
 </section>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -5,3 +5,10 @@
   <h4>Customer:</h4>
   <p><%="#{@invoice.customer.first_name} #{@invoice.customer.last_name}"%></p>
 </section>
+
+<section id="invoice-item-details">
+  <h4>Items on the Invoice:</h4>
+  <% @invoice.items.each do |item| %>
+    <p><%= item%></p>
+  <% end %>
+</section>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -1,12 +1,17 @@
 <section id="invoice-details">
   <h2><%= "Invoice ##{@invoice.id}"%></h2>
-  <p><%= "Status: #{@invoice.status}"%></p>
+  <p>Status: </p>
+  <%= form_with model: @invoice, url: admin_invoice_path(@invoice), method: :patch do |form| %>
+    <%= form.select :status, Invoice.statuses.keys, selected: @invoice.status %>
+    <%= form.submit "Update Invoice" %>
+  <% end %>
   <p><%= "Created on: #{@invoice.created_at.strftime("%A, %B %d, %Y")}"%></p>
   <p> Total Revenue: <%= number_to_currency(@invoice.total_revenue) %></p>
   <h4>Customer:</h4>
   <p><%="#{@invoice.customer.first_name} #{@invoice.customer.last_name}"%></p>
 </section>
 
+  
 <section id="invoice-item-details">
   <h4>Items on the Invoice:</h4>
   <ul>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -2,6 +2,7 @@
   <h2><%= "Invoice ##{@invoice.id}"%></h2>
   <p><%= "Status: #{@invoice.status}"%></p>
   <p><%= "Created on: #{@invoice.created_at.strftime("%A, %B %d, %Y")}"%></p>
+  <p> Total Revenue: <%= number_to_currency(@invoice.total_revenue) %></p>
   <h4>Customer:</h4>
   <p><%="#{@invoice.customer.first_name} #{@invoice.customer.last_name}"%></p>
 </section>

--- a/app/views/admin/invoices/show.html.erb
+++ b/app/views/admin/invoices/show.html.erb
@@ -10,10 +10,10 @@
   <h4>Items on the Invoice:</h4>
   <ul>
     <% @invoice.items.each do |item| %>
-      <p><%= item.name %></p>
-      <li>Quantity: <%= item.num_sold(@invoice) %></li>
-      <li>Unit Price: <%= number_to_currency(item.price_sold(@invoice), format: '%u%n', unit: '$') %></li>
-      <li>Status: <%= item.invoice_status(@invoice) %></li>
+      <li><%= item.name %></li>
+      <p>Quantity: <%= item.num_sold(@invoice) %></p>
+      <p>Unit Price: <%= number_to_currency(item.price_sold(@invoice)) %></p>
+      <p>Status: <%= item.invoice_status(@invoice) %></p>
     <% end %>
   </ul>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :merchants, except: [:destroy], controller: "merchants"
-    resources :invoices, only: [:index, :show]
+    resources :invoices, only: [:index, :show, :update]
   end
 
   resources :merchants do

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Admin Invoice Show Page" do
     # User Story 35
     it "displays the total revenue for the invoice" do
       visit admin_invoice_path(@invoice_1)
-      save_and_open_page
+
       within("#invoice-details") do
         expect(page).to have_content("Total Revenue: $6,500.00")
       end
@@ -86,6 +86,43 @@ RSpec.describe "Admin Invoice Show Page" do
       visit admin_invoice_path(@invoice_2)
       within("#invoice-details") do
         expect(page).to have_content("Total Revenue: $5,500.00")
+      end
+    end
+  end
+
+  describe "Admin Invoice Item Status Update" do
+    # User Story 36
+    it "displays a select field 'invoice status' with current status as default" do
+      visit admin_invoice_path(@invoice_1)
+
+      within("#invoice-item-details") do
+        expect(page).to have_select("invoice_status", selected: "#@invoice_1.status")
+      end
+
+      visit admin_invoice_path(@invoice_2)
+
+      within("#invoice-item-details") do
+        expect(page).to have_select("invoice_status", selected: "#@invoice_2.status")
+      end
+    end
+
+    it "allows me to select a new status and submit the form" do
+      visit admin_invoice_path(@invoice_1)
+
+      within("#invoice-item-details") do
+        expect(@invoice_1.status).to eq("in progress")
+
+        select("completed", from: "invoice_status")
+        click_button("Update Invoice")
+        @invoice_1.reload
+        expect(page).to have_current_path(admin_invoice_path(@invoice_1))
+        expect(@invoice_1.status).to eq("completed")
+
+        select("cancelled", from: "invoice_status")
+        click_button("Update Invoice")
+        @invoice_1.reload
+        expect(page).to have_current_path(admin_invoice_path(@invoice_1))
+        expect(@invoice_1.status).to eq("cancelled")
       end
     end
   end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -74,5 +74,19 @@ RSpec.describe "Admin Invoice Show Page" do
         expect(page).to_not have_content(@item_6.name)
       end
     end
+
+    # User Story 35
+    it "displays the total revenue for the invoice" do
+      visit admin_invoice_path(@invoice_1)
+      save_and_open_page
+      within("#invoice-details") do
+        expect(page).to have_content("Total Revenue: $6,500.00")
+      end
+
+      visit admin_invoice_path(@invoice_2)
+      within("#invoice-details") do
+        expect(page).to have_content("Total Revenue: $5,500.00")
+      end
+    end
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -2,10 +2,25 @@ require "rails_helper"
 
 RSpec.describe "Admin Invoice Show Page" do
   before(:each) do
+    @merchant_1 = create(:merchant)
     @customer_1 = create(:customer)
     @customer_2 = create(:customer)
+    @item_1 = create(:item, merchant: @merchant_1)
+    @item_2 = create(:item, merchant: @merchant_1)
+    @item_3 = create(:item, merchant: @merchant_1)
+    @item_4 = create(:item, merchant: @merchant_1)
+    @item_5 = create(:item, merchant: @merchant_1)
+    @item_6 = create(:item, merchant: @merchant_1)
     @invoice_1 = create(:invoice, customer: @customer_1)
     @invoice_2 = create(:invoice, customer: @customer_2)
+    @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, status: 1)
+    @invoice_item_2 = InvoiceItem.create!(item_id: @item_2.id, invoice_id: @invoice_1.id, status: 1)
+    @invoice_item_3 = InvoiceItem.create!(item_id: @item_3.id, invoice_id: @invoice_1.id, status: 0)
+    @invoice_item_4 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_1.id, status: 2)
+    @invoice_item_5 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_2.id, status: 1)
+    @invoice_item_6 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_2.id, status: 1)
+    @invoice_item_7 = InvoiceItem.create!(item_id: @item_5.id, invoice_id: @invoice_2.id, status: 2)
+    @invoice_item_8 = InvoiceItem.create!(item_id: @item_6.id, invoice_id: @invoice_2.id, status: 0)
   end
 
   describe "Admin Invoice Details" do
@@ -24,6 +39,15 @@ RSpec.describe "Admin Invoice Show Page" do
 
         expect(page).to_not have_content("Invoice ##{@invoice_2.id}")
       end
+    end
+  end
+
+  describe "Admin Invoice Items Details" do
+    # User Story 34
+    it "displays all of the items on the invoice with their details" do
+      visit admin_invoice_path(@invoice_1)
+      require 'pry'; binding.pry
+
     end
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -46,10 +46,32 @@ RSpec.describe "Admin Invoice Show Page" do
     # User Story 34
     it "displays all of the items on the invoice with their details" do
       visit admin_invoice_path(@invoice_1)
-      save_and_open_page
+
       within("#invoice-item-details") do
         expect(page).to have_content("Items on the Invoice:")
+
         expect(page).to have_content(@item_1.name)
+        expect(page).to have_content("Quantity: #{@invoice_item_1.quantity}")
+        expect(page).to have_content("Unit Price: $100.00")
+        expect(page).to have_content("Status: #{@invoice_item_1.status}")
+
+        expect(page).to have_content(@item_2.name)
+        expect(page).to have_content("Quantity: #{@invoice_item_2.quantity}")
+        expect(page).to have_content("Unit Price: $50.00")
+        expect(page).to have_content("Status: #{@invoice_item_2.status}")
+
+        expect(page).to have_content(@item_3.name)
+        expect(page).to have_content("Quantity: #{@invoice_item_3.quantity}")
+        expect(page).to have_content("Unit Price: $1,000.00")
+        expect(page).to have_content("Status: #{@invoice_item_3.status}")
+
+        expect(page).to have_content(@item_4.name)
+        expect(page).to have_content("Quantity: #{@invoice_item_4.quantity}")
+        expect(page).to have_content("Unit Price: $500.00")
+        expect(page).to have_content("Status: #{@invoice_item_4.status}")
+
+        expect(page).to_not have_content(@item_5.name)
+        expect(page).to_not have_content(@item_6.name)
       end
     end
   end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe "Admin Invoice Show Page" do
     @item_6 = create(:item, merchant: @merchant_1)
     @invoice_1 = create(:invoice, customer: @customer_1)
     @invoice_2 = create(:invoice, customer: @customer_2)
-    @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, status: 1)
-    @invoice_item_2 = InvoiceItem.create!(item_id: @item_2.id, invoice_id: @invoice_1.id, status: 1)
-    @invoice_item_3 = InvoiceItem.create!(item_id: @item_3.id, invoice_id: @invoice_1.id, status: 0)
-    @invoice_item_4 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_1.id, status: 2)
-    @invoice_item_5 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_2.id, status: 1)
-    @invoice_item_6 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_2.id, status: 1)
-    @invoice_item_7 = InvoiceItem.create!(item_id: @item_5.id, invoice_id: @invoice_2.id, status: 2)
-    @invoice_item_8 = InvoiceItem.create!(item_id: @item_6.id, invoice_id: @invoice_2.id, status: 0)
+    @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, status: 1, quantity: 10, unit_price: 100)
+    @invoice_item_2 = InvoiceItem.create!(item_id: @item_2.id, invoice_id: @invoice_1.id, status: 1, quantity: 20, unit_price: 50)
+    @invoice_item_3 = InvoiceItem.create!(item_id: @item_3.id, invoice_id: @invoice_1.id, status: 0, quantity: 2, unit_price: 1000)
+    @invoice_item_4 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_1.id, status: 2, quantity: 5, unit_price: 500)
+    @invoice_item_5 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_2.id, status: 1, quantity: 1, unit_price: 100)
+    @invoice_item_6 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_2.id, status: 1, quantity: 10, unit_price: 500)
+    @invoice_item_7 = InvoiceItem.create!(item_id: @item_5.id, invoice_id: @invoice_2.id, status: 2, quantity: 100, unit_price: 2)
+    @invoice_item_8 = InvoiceItem.create!(item_id: @item_6.id, invoice_id: @invoice_2.id, status: 0, quantity: 20, unit_price: 10)
   end
 
   describe "Admin Invoice Details" do
@@ -46,8 +46,11 @@ RSpec.describe "Admin Invoice Show Page" do
     # User Story 34
     it "displays all of the items on the invoice with their details" do
       visit admin_invoice_path(@invoice_1)
-      require 'pry'; binding.pry
-
+      save_and_open_page
+      within("#invoice-item-details") do
+        expect(page).to have_content("Items on the Invoice:")
+        expect(page).to have_content(@item_1.name)
+      end
     end
   end
 end

--- a/spec/features/admin/invoices/show_spec.rb
+++ b/spec/features/admin/invoices/show_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Admin Invoice Show Page" do
     @item_4 = create(:item, merchant: @merchant_1)
     @item_5 = create(:item, merchant: @merchant_1)
     @item_6 = create(:item, merchant: @merchant_1)
-    @invoice_1 = create(:invoice, customer: @customer_1)
+    @invoice_1 = create(:invoice, customer: @customer_1, status: 0)
     @invoice_2 = create(:invoice, customer: @customer_2)
     @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, status: 1, quantity: 10, unit_price: 100)
     @invoice_item_2 = InvoiceItem.create!(item_id: @item_2.id, invoice_id: @invoice_1.id, status: 1, quantity: 20, unit_price: 50)
@@ -30,7 +30,6 @@ RSpec.describe "Admin Invoice Show Page" do
 
       within("#invoice-details") do
         expect(page).to have_content("Invoice ##{@invoice_1.id}")
-        expect(page).to have_content("Status: #{@invoice_1.status}")
         expect(page).to have_content("Created on: #{@invoice_1.created_at.strftime("%A, %B %d, %Y")}")
 
         expect(page).to have_content("Customer:")
@@ -92,35 +91,23 @@ RSpec.describe "Admin Invoice Show Page" do
 
   describe "Admin Invoice Item Status Update" do
     # User Story 36
-    it "displays a select field 'invoice status' with current status as default" do
+    it "displays a status select field that updates the invoice's status" do
       visit admin_invoice_path(@invoice_1)
 
-      within("#invoice-item-details") do
-        expect(page).to have_select("invoice_status", selected: "#@invoice_1.status")
-      end
-
-      visit admin_invoice_path(@invoice_2)
-
-      within("#invoice-item-details") do
-        expect(page).to have_select("invoice_status", selected: "#@invoice_2.status")
-      end
-    end
-
-    it "allows me to select a new status and submit the form" do
-      visit admin_invoice_path(@invoice_1)
-
-      within("#invoice-item-details") do
+      within("#invoice-details") do
         expect(@invoice_1.status).to eq("in progress")
 
-        select("completed", from: "invoice_status")
-        click_button("Update Invoice")
+        select("completed", :from => 'invoice[status]')
+        click_button 'Update Invoice'
         @invoice_1.reload
+
         expect(page).to have_current_path(admin_invoice_path(@invoice_1))
         expect(@invoice_1.status).to eq("completed")
 
-        select("cancelled", from: "invoice_status")
+        select("cancelled", :from => 'invoice[status]')
         click_button("Update Invoice")
         @invoice_1.reload
+        
         expect(page).to have_current_path(admin_invoice_path(@invoice_1))
         expect(@invoice_1.status).to eq("cancelled")
       end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe Invoice, type: :model do
     @invoice_1 = @customer_1.invoices.create!(status: 1)
     @invoice_2 = @customer_1.invoices.create!(status: 1)
     @invoice_3 = @customer_2.invoices.create!(status: 1)
-    @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, status: 0)
-    @invoice_item_2 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_2.id, status: 2)
-    @invoice_item_3 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_3.id, status: 2)
-    @invoice_item_4 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_3.id, status: 1)
-    @invoice_item_5 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, status: 1)
+    @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, status: 0, quantity: 10, unit_price: 100)
+    @invoice_item_2 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_2.id, status: 2, quantity: 20, unit_price: 50)
+    @invoice_item_3 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_3.id, status: 2, quantity: 2, unit_price: 1000)
+    @invoice_item_4 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_3.id, status: 1, quantity: 5, unit_price: 500)
+    @invoice_item_5 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, status: 1, quantity: 1, unit_price: 100)
   end
 
   describe "Class Methods" do
@@ -29,6 +29,16 @@ RSpec.describe Invoice, type: :model do
       it "returns the invoices with items that have not been shipped" do
         expect(Invoice.incomplete_invoices).to include(@invoice_1, @invoice_3)
         expect(Invoice.incomplete_invoices).to_not include(@invoice_2)
+      end
+    end
+  end
+
+  describe "Instance Methods" do
+    describe "#total_revenue" do
+      it "returns the total revenue for an invoice" do
+        expect(@invoice_1.total_revenue).to eq(1100)
+        expect(@invoice_2.total_revenue).to eq(1000)
+        expect(@invoice_3.total_revenue).to eq(4500)
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -29,19 +29,33 @@ RSpec.describe Item, type: :model do
     @invoice_item_5 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_2.id, status: 1, quantity: 1, unit_price: 100)
     @invoice_item_6 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_2.id, status: 1, quantity: 10, unit_price: 500)
   end
+
   describe "Instance Methods" do
-    it "#num_sold" do
-      expect(@item_1.num_sold(@invoice_1)).to eq(@invoice_item_1.quantity)
-      expect(@item_1.num_sold(@invoice_2)).to eq(@invoice_item_5.quantity)
-      expect(@item_2.num_sold(@invoice_1)).to eq(@invoice_item_2.quantity)
-      expect(@item_3.num_sold(@invoice_1)).to eq(@invoice_item_3.quantity)
+    describe "#num_sold" do
+      it "find the number of items sold on a specific invoice" do
+        expect(@item_1.num_sold(@invoice_1)).to eq(@invoice_item_1.quantity)
+        expect(@item_1.num_sold(@invoice_2)).to eq(@invoice_item_5.quantity)
+        expect(@item_2.num_sold(@invoice_1)).to eq(@invoice_item_2.quantity)
+        expect(@item_3.num_sold(@invoice_1)).to eq(@invoice_item_3.quantity)
+      end
     end
 
-    it "#unit_price" do
-      expect(@item_1.price_sold(@invoice_1)).to eq(@invoice_item_1.unit_price)
-      expect(@item_1.price_sold(@invoice_2)).to eq(@invoice_item_5.unit_price)
-      expect(@item_2.price_sold(@invoice_1)).to eq(@invoice_item_2.unit_price)
-      expect(@item_4.price_sold(@invoice_2)).to eq(@invoice_item_6.unit_price)
+    describe "#unit_price" do
+      it "find the unit price of an item on a specific invoice" do
+        expect(@item_1.price_sold(@invoice_1)).to eq(@invoice_item_1.unit_price)
+        expect(@item_1.price_sold(@invoice_2)).to eq(@invoice_item_5.unit_price)
+        expect(@item_2.price_sold(@invoice_1)).to eq(@invoice_item_2.unit_price)
+        expect(@item_4.price_sold(@invoice_2)).to eq(@invoice_item_6.unit_price)
+      end
+    end
+
+    describe "#invoice_status" do
+      it "find the status of an item on a specific invoice" do
+        expect(@item_1.invoice_status(@invoice_1)).to eq(@invoice_item_1.status)
+        expect(@item_1.invoice_status(@invoice_2)).to eq(@invoice_item_5.status)
+        expect(@item_2.invoice_status(@invoice_1)).to eq(@invoice_item_2.status)
+        expect(@item_4.invoice_status(@invoice_2)).to eq(@invoice_item_6.status)
+      end
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,12 +5,43 @@ RSpec.describe Item, type: :model do
     it { should belong_to(:merchant)}
     it { should have_many(:invoice_items)}
     it { should have_many(:invoices).through(:invoice_items)}
-
+  end
     
-    describe "Validations" do
-      it { should validate_presence_of :name }
-      it { should validate_presence_of :description }
-      it { should validate_presence_of :unit_price }
+  describe "Validations" do
+    it { should validate_presence_of :name }
+    it { should validate_presence_of :description }
+    it { should validate_presence_of :unit_price }
+  end
+
+  before(:each) do
+    @merchant_1 = create(:merchant)
+    @customer_1 = create(:customer)
+    @item_1 = create(:item, merchant: @merchant_1)
+    @item_2 = create(:item, merchant: @merchant_1)
+    @item_3 = create(:item, merchant: @merchant_1)
+    @item_4 = create(:item, merchant: @merchant_1)
+    @invoice_1 = create(:invoice, customer: @customer_1)
+    @invoice_2 = create(:invoice, customer: @customer_1)
+    @invoice_item_1 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_1.id, status: 1, quantity: 10, unit_price: 100)
+    @invoice_item_2 = InvoiceItem.create!(item_id: @item_2.id, invoice_id: @invoice_1.id, status: 1, quantity: 20, unit_price: 50)
+    @invoice_item_3 = InvoiceItem.create!(item_id: @item_3.id, invoice_id: @invoice_1.id, status: 0, quantity: 2, unit_price: 1000)
+    @invoice_item_4 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_1.id, status: 2, quantity: 5, unit_price: 500)
+    @invoice_item_5 = InvoiceItem.create!(item_id: @item_1.id, invoice_id: @invoice_2.id, status: 1, quantity: 1, unit_price: 100)
+    @invoice_item_6 = InvoiceItem.create!(item_id: @item_4.id, invoice_id: @invoice_2.id, status: 1, quantity: 10, unit_price: 500)
+  end
+  describe "Instance Methods" do
+    it "#num_sold" do
+      expect(@item_1.num_sold(@invoice_1)).to eq(@invoice_item_1.quantity)
+      expect(@item_1.num_sold(@invoice_2)).to eq(@invoice_item_5.quantity)
+      expect(@item_2.num_sold(@invoice_1)).to eq(@invoice_item_2.quantity)
+      expect(@item_3.num_sold(@invoice_1)).to eq(@invoice_item_3.quantity)
+    end
+
+    it "#unit_price" do
+      expect(@item_1.price_sold(@invoice_1)).to eq(@invoice_item_1.unit_price)
+      expect(@item_1.price_sold(@invoice_2)).to eq(@invoice_item_5.unit_price)
+      expect(@item_2.price_sold(@invoice_1)).to eq(@invoice_item_2.unit_price)
+      expect(@item_4.price_sold(@invoice_2)).to eq(@invoice_item_6.unit_price)
     end
   end
 end


### PR DESCRIPTION
Completes User Stories: 34, 35, and 36:
- Displays all the items for an invoice on its show page
- Displays the total revenue for an invoice on its show page
- Changes invoice status to selectable field (current status is set as the default)